### PR TITLE
Updated tigervnc to 1.12.0

### DIFF
--- a/packages/manual/tigervnc_m/tigervnc-viewer/tigervnc-viewer.nuspec
+++ b/packages/manual/tigervnc_m/tigervnc-viewer/tigervnc-viewer.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>tigervnc-viewer</id>
     <title>TigerVNC Viewer</title>
-    <version>1.10.1</version>
+    <version>1.12.0</version>
     <authors>TigerVNC Team et al.</authors>
     <owners>qzo</owners>
     <summary>TigerVNC is a high-performance, platform-neutral implementation of VNC (Virtual Network Computing), a client/server application that allows users to launch and interact with graphical applications on remote machines.</summary>
@@ -15,7 +15,7 @@
     <licenseUrl>http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/qzo/chocolatey-packages/6855e891ea4e897729b4d5d5a17787e3afaa4b0d/icons/tigervnc.png</iconUrl>
-    <releaseNotes>https://github.com/TigerVNC/tigervnc/releases/tag/v1.10.1</releaseNotes>
+    <releaseNotes>https://github.com/TigerVNC/tigervnc/releases/tag/v1.12.0</releaseNotes>
     <packageSourceUrl>https://github.com/qzo/chocolatey-packages/tree/master/packages/manual/tigervnc_m/tigervnc-viewer</packageSourceUrl>
     <projectSourceUrl>https://github.com/TigerVNC/tigervnc</projectSourceUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/tigervnc-users</mailingListUrl>

--- a/packages/manual/tigervnc_m/tigervnc-viewer/tools/chocolateyInstall.ps1
+++ b/packages/manual/tigervnc_m/tigervnc-viewer/tools/chocolateyInstall.ps1
@@ -3,12 +3,12 @@ $appName = 'TigerVNC Viewer'
 $processName = 'vncviewer*'
 
 $is64 = ((Get-ProcessorBits 64) -and !$env:chocolateyForceX86)
-$url32 = 'https://bintray.com/tigervnc/stable/download_file?file_path=vncviewer-1.10.1.exe'
-$url64 = 'https://bintray.com/tigervnc/stable/download_file?file_path=vncviewer64-1.10.1.exe'
+$url32 = 'https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/vncviewer-1.12.0.exe/download#'
+$url64 = 'https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/vncviewer64-1.12.0.exe/download#'
 $url = If ($is64) { $url64 } Else { $url32 }
-$fileName = $url.SubString($url.LastIndexOf('=') + 1)
-$checksum32 = '93b386bc135ade63d2bec5f5b30c1203e689e5be1fe71fc451505a0e7c4ec46c043c9e8a200257f98ae18a39b676c542b15f0985e0e14bacffc46b1449d95f51'
-$checksum64 = '5ed69fcf2a127324865861a2cdbb37ada1e37edebd8ed36bf4111cba7c9d5e8d4726e202695f242ac67bcc26f1e655fbc98a00bd34e47ed227bf834e8a9db534'
+$fileName = ($url -split '/')[8]
+$checksum32 = '4eeb353b1764ce792a9e92b4cdfa4c64e1139f8c704f854e1fd841fab871ce724720cb55e0fe7af5fb948f01502460244150926ccf6e226d87113235100f0a8b'
+$checksum64 = 'a3e15fc3409c7d8899443a3e09312a47fd750e4547ee3cdaab8c9363a83bd953444ba5461b9a2651d1983c5ce3a38b96688b3c4d5b6bdf276090005f5c6176b6'
 $checksumType = 'sha512'
 
 $dir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)

--- a/packages/manual/tigervnc_m/tigervnc-viewer/tools/chocolateyInstall.ps1.php
+++ b/packages/manual/tigervnc_m/tigervnc-viewer/tools/chocolateyInstall.ps1.php
@@ -7,7 +7,7 @@ $is64 = ((Get-ProcessorBits 64) -and !$env:chocolateyForceX86)
 $url32 = '<?php echo URL32; ?>'
 $url64 = '<?php echo URL64; ?>'
 $url = If ($is64) { $url64 } Else { $url32 }
-$fileName = $url.SubString($url.LastIndexOf('=') + 1)
+$fileName = ($url -split '/')[8]
 $checksum32 = '<?php echo CHECKSUM32; ?>'
 $checksum64 = '<?php echo CHECKSUM64; ?>'
 $checksumType = 'sha512'

--- a/packages/manual/tigervnc_m/tigervnc-viewer/vars.inc
+++ b/packages/manual/tigervnc_m/tigervnc-viewer/vars.inc
@@ -1,8 +1,8 @@
 <?php require (dirname(__DIR__) . '/vars.inc');
 
-define('URL32', 'https://bintray.com/tigervnc/stable/download_file?file_path=vncviewer-1.10.1.exe');
-define('URL64', 'https://bintray.com/tigervnc/stable/download_file?file_path=vncviewer64-1.10.1.exe');
-define('CHECKSUM32', '93b386bc135ade63d2bec5f5b30c1203e689e5be1fe71fc451505a0e7c4ec46c043c9e8a200257f98ae18a39b676c542b15f0985e0e14bacffc46b1449d95f51');
-define('CHECKSUM64', '5ed69fcf2a127324865861a2cdbb37ada1e37edebd8ed36bf4111cba7c9d5e8d4726e202695f242ac67bcc26f1e655fbc98a00bd34e47ed227bf834e8a9db534');
+define('URL32', 'https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/vncviewer-1.12.0.exe/download#');
+define('URL64', 'https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/vncviewer64-1.12.0.exe/download#');
+define('CHECKSUM32', '4eeb353b1764ce792a9e92b4cdfa4c64e1139f8c704f854e1fd841fab871ce724720cb55e0fe7af5fb948f01502460244150926ccf6e226d87113235100f0a8b');
+define('CHECKSUM64', 'a3e15fc3409c7d8899443a3e09312a47fd750e4547ee3cdaab8c9363a83bd953444ba5461b9a2651d1983c5ce3a38b96688b3c4d5b6bdf276090005f5c6176b6');
 
 ?>

--- a/packages/manual/tigervnc_m/tigervnc/tigervnc.nuspec
+++ b/packages/manual/tigervnc_m/tigervnc/tigervnc.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>tigervnc</id>
     <title>TigerVNC</title>
-    <version>1.10.1</version>
+    <version>1.12.0</version>
     <authors>TigerVNC Team et al.</authors>
     <owners>qzo</owners>
     <summary>TigerVNC is a high-performance, platform-neutral implementation of VNC (Virtual Network Computing), a client/server application that allows users to launch and interact with graphical applications on remote machines.</summary>
@@ -15,7 +15,7 @@
     <licenseUrl>http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/qzo/chocolatey-packages/6855e891ea4e897729b4d5d5a17787e3afaa4b0d/icons/tigervnc.png</iconUrl>
-    <releaseNotes>https://github.com/TigerVNC/tigervnc/releases/tag/v1.10.1</releaseNotes>
+    <releaseNotes>https://github.com/TigerVNC/tigervnc/releases/tag/v1.12.0</releaseNotes>
     <packageSourceUrl>https://github.com/qzo/chocolatey-packages/tree/master/packages/manual/tigervnc_m/tigervnc</packageSourceUrl>
     <projectSourceUrl>https://github.com/TigerVNC/tigervnc</projectSourceUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/tigervnc-users</mailingListUrl>

--- a/packages/manual/tigervnc_m/tigervnc/tools/chocolateyInstall.ps1
+++ b/packages/manual/tigervnc_m/tigervnc/tools/chocolateyInstall.ps1
@@ -1,9 +1,9 @@
 ﻿$packageName = 'tigervnc'
 $installerType = 'exe'
-$url32 = 'https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc-1.10.1.exe'
-$url64 = 'https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc64-1.10.1.exe'
-$checksum32 = '0d9e7666d3ead261be6b483e1e01392e7764309703da818055705c5296f279f31708375f6321e2285c65a40247092a390a0e0b1fa14910990037cec24e79265c'
-$checksum64 = '9c60d02be8a49ea05b8df482d45f9a12d6c6716896b893e643ce38aba3dc2127f029ba2659394f3b628e6a2cd3ae9e7b2b2d95c246595dfc583c3f54bb4c24d0'
+$url32 = 'https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/tigervnc-1.12.0.exe/download#'
+$url64 = 'https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/tigervnc64-1.12.0.exe/download#'
+$checksum32 = 'c879d0ebb587d6a91bf50104046fcda388a533b9e075a7e38febe0a44d0a8fcde7a752622092a59a2964e6615057d7899d75b3ded77d3080d3fae0f55ec0f9b4'
+$checksum64 = 'c9a4ae198ba2503d3fe4c70c001d4567a891a68c534ceccf80430976b4a5d767eae8f00a3bda7e24fbbe07ac60a4ee1d1c5836e1e44fc9b52d4b17d64f7e6bc5'
 $checksumType = 'sha512'
 $silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 $validExitCodes = @(0)

--- a/packages/manual/tigervnc_m/tigervnc/vars.inc
+++ b/packages/manual/tigervnc_m/tigervnc/vars.inc
@@ -1,8 +1,8 @@
 <?php require (dirname(__DIR__) . '/vars.inc');
 
-define('URL32', 'https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc-1.10.1.exe');
-define('URL64', 'https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc64-1.10.1.exe');
-define('CHECKSUM32', '0d9e7666d3ead261be6b483e1e01392e7764309703da818055705c5296f279f31708375f6321e2285c65a40247092a390a0e0b1fa14910990037cec24e79265c');
-define('CHECKSUM64', '9c60d02be8a49ea05b8df482d45f9a12d6c6716896b893e643ce38aba3dc2127f029ba2659394f3b628e6a2cd3ae9e7b2b2d95c246595dfc583c3f54bb4c24d0');
+define('URL32', 'https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/tigervnc-1.12.0.exe/download#');
+define('URL64', 'https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/tigervnc64-1.12.0.exe/download#');
+define('CHECKSUM32', 'c879d0ebb587d6a91bf50104046fcda388a533b9e075a7e38febe0a44d0a8fcde7a752622092a59a2964e6615057d7899d75b3ded77d3080d3fae0f55ec0f9b4');
+define('CHECKSUM64', 'c9a4ae198ba2503d3fe4c70c001d4567a891a68c534ceccf80430976b4a5d767eae8f00a3bda7e24fbbe07ac60a4ee1d1c5836e1e44fc9b52d4b17d64f7e6bc5');
 
 ?>

--- a/packages/manual/tigervnc_m/vars.inc
+++ b/packages/manual/tigervnc_m/vars.inc
@@ -1,7 +1,7 @@
 <?php
 
-define('VERSION', '1.10.1');
-define('RELEASE_NOTES', 'https://github.com/TigerVNC/tigervnc/releases/tag/v1.10.1');
+define('VERSION', '1.12.0');
+define('RELEASE_NOTES', 'https://github.com/TigerVNC/tigervnc/releases/tag/v1.12.0');
 
 define('SUMMARY', 'TigerVNC is a high-performance, platform-neutral implementation of VNC (Virtual Network Computing), a client/server application that allows users to launch and interact with graphical applications on remote machines.');
 


### PR DESCRIPTION
Updated to latest version, 1.12.0

Source for binaries changed to SourceForge as BinTray has been sunset and is no longer available.